### PR TITLE
SDKS-2033 Android 13 Push notification changes

### DIFF
--- a/forgerock-authenticator/CHANGELOG.md
+++ b/forgerock-authenticator/CHANGELOG.md
@@ -1,6 +1,18 @@
-# Version 1.0.0
+# Version 1.1.0
+
+## [1.1.0]
+
+#### Updated
+
+- Android `forgerock-authenticator` dependency to the latest release.
+
+#### Added
+- New attributes on `PushNotification` model
+- New `PushType` model
+- New APIs to handle Biometric and Challenge push types
 
 ## [1.0.0]
 
 #### Added
 - Initial release of ForgeRock Authenticator for Flutter
+

--- a/forgerock-authenticator/android/build.gradle
+++ b/forgerock-authenticator/android/build.gradle
@@ -23,7 +23,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -31,16 +31,25 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
     }
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation 'androidx.annotation:annotation:1.4.0'
+    implementation 'androidx.activity:activity:1.5.1'
     implementation 'com.google.firebase:firebase-messaging:21.1.0'
     implementation 'com.google.android.gms:play-services-location:18.0.0'
 
-    implementation 'org.forgerock:forgerock-authenticator:3.3.3'
-    implementation 'org.forgerock:forgerock-core:3.3.3'
+    implementation 'org.forgerock:forgerock-authenticator:3.4.0'
+    implementation 'org.forgerock:forgerock-core:3.4.0'
+
+    //add lib via aar-depency
+//    compile(name: 'forgerock-authenticator-debug', ext: 'aar')
+//    compile(name: 'forgerock-core-debug', ext: 'aar')
+//    implementation 'com.nimbusds:nimbus-jose-jwt:9.0.1'
+//    implementation 'com.squareup.okhttp3:okhttp:4.3.1'
+//    implementation 'com.squareup.okhttp3:logging-interceptor:4.3.1'
+//    implementation 'androidx.biometric:biometric-ktx:1.2.0-alpha04'
 }
 

--- a/forgerock-authenticator/android/src/main/java/org/forgerock/android/auth/FRANotificationPermissionHelper.java
+++ b/forgerock-authenticator/android/src/main/java/org/forgerock/android/auth/FRANotificationPermissionHelper.java
@@ -1,0 +1,106 @@
+package org.forgerock.android.auth;
+
+import android.Manifest;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.ActivityCompat;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+public class FRANotificationPermissionHelper extends Fragment {
+
+    static final String TAG = FRANotificationPermissionHelper.class.getName();
+
+    private static final int REQUEST_NOTIFICATION_PERMISSION = 101;
+
+    private FragmentActivity activity;
+
+    private FRANotificationPermissionHelper() {}
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        activity = null;
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode,
+                                           @NonNull String[] permissions,
+                                           @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if (requestCode == REQUEST_NOTIFICATION_PERMISSION) {
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                Logger.debug(TAG, "Notification permission granted.");
+            } else {
+                Logger.debug(TAG, "Notification permission denied.");
+            }
+        }
+    }
+
+    /**
+     * Request the new notification permission to the app
+     */
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    public void requestNotificationPermission() {
+        if(ActivityCompat.shouldShowRequestPermissionRationale(this.activity, Manifest.permission.POST_NOTIFICATIONS)) {
+//            final FragmentActivity _activity = this.activity;
+//            new AlertDialog.Builder(this.activity)
+//                    .setTitle("Notification Permission required")
+//                    .setMessage("Notification Permission is needed in order to receive Push Authentication requests on your device. " +
+//                            "If you deny, you will be unable to use Push accounts. Do you want to enable Notifications?")
+//                    .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+//                        @Override
+//                        public void onClick(DialogInterface dialog, int which) {
+//                            ActivityCompat.requestPermissions(
+//                                    _activity,
+//                                    new String[]{Manifest.permission.POST_NOTIFICATIONS},
+//                                    REQUEST_NOTIFICATION_PERMISSION);
+//                        }
+//                    })
+//                    .setNegativeButton("No", new DialogInterface.OnClickListener() {
+//                        @Override
+//                        public void onClick(DialogInterface dialog, int which) {
+//                            dialog.dismiss();
+//                        }
+//                    }).create().show();
+        } else {
+            ActivityCompat.requestPermissions(
+                    this.activity,
+                    new String[]{Manifest.permission.POST_NOTIFICATIONS},
+                    REQUEST_NOTIFICATION_PERMISSION);
+        }
+    }
+
+    /**
+     * Initialize a fragment to handle Notification permission request.
+     * @param activity the activity that will host the new Fragment
+     * @return the Fragment
+     */
+   public static FRANotificationPermissionHelper init(FragmentActivity activity) {
+        FragmentManager fragmentManager = activity.getSupportFragmentManager();
+        FRANotificationPermissionHelper existing = (FRANotificationPermissionHelper) fragmentManager.findFragmentByTag(TAG);
+        if (existing != null) {
+            existing.activity = null;
+            fragmentManager.beginTransaction().remove(existing).commitNow();
+        }
+
+        FRANotificationPermissionHelper fragment = new FRANotificationPermissionHelper();
+        fragment.activity = activity;
+        fragmentManager.beginTransaction().add(fragment, FRANotificationPermissionHelper.TAG).commit();
+
+        return fragment;
+    }
+
+}

--- a/forgerock-authenticator/example/android/app/build.gradle
+++ b/forgerock-authenticator/example/android/app/build.gradle
@@ -34,12 +34,12 @@ if (keystorePropertiesFileExists) {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.example.authenticator"
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
 

--- a/forgerock-authenticator/example/android/app/src/main/AndroidManifest.xml
+++ b/forgerock-authenticator/example/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
    <application
         android:hardwareAccelerated="true"

--- a/forgerock-authenticator/example/lib/providers/authenticator_provider.dart
+++ b/forgerock-authenticator/example/lib/providers/authenticator_provider.dart
@@ -70,8 +70,22 @@ class AuthenticatorProvider with ChangeNotifier {
     return ForgerockAuthenticator.getOathTokenCode(mechanismId);
   }
 
-  static Future<bool> performPushAuthentication(PushNotification pushNotification, bool accept) async {
+  static Future<bool> performPushAuthentication(PushNotification pushNotification,
+      bool accept) async {
     return ForgerockAuthenticator.performPushAuthentication(pushNotification, accept);
+  }
+
+  static Future<bool> performPushAuthenticationWithChallenge(
+      PushNotification pushNotification, String challengeResponse, bool accept) async {
+    return ForgerockAuthenticator.performPushAuthenticationWithChallenge(pushNotification,
+        challengeResponse, accept);
+  }
+
+  static Future<bool> performPushAuthenticationWithBiometric(
+      PushNotification pushNotification, String title,
+      bool allowDeviceCredentials, bool accept) async {
+    return ForgerockAuthenticator.performPushAuthenticationWithBiometric(pushNotification,
+        title, allowDeviceCredentials, accept);
   }
 
 }

--- a/forgerock-authenticator/example/lib/widgets/account_circle_avatar.dart
+++ b/forgerock-authenticator/example/lib/widgets/account_circle_avatar.dart
@@ -7,7 +7,7 @@
 
 import 'package:flutter/material.dart';
 
-/// This widget creates a [CircleAvatar] to reprsent the [Account].
+/// This widget creates a [CircleAvatar] to represent the [Account].
 class AccountCircleAvatar extends StatelessWidget {
 
   final String text;

--- a/forgerock-authenticator/example/lib/widgets/challenge_button.dart
+++ b/forgerock-authenticator/example/lib/widgets/challenge_button.dart
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+import 'package:flutter/material.dart';
+
+
+class ChallengeButton extends StatelessWidget {
+
+  final VoidCallback action;
+  final String text;
+
+  const ChallengeButton({Key key, this.action, this.text}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(15, 5, 15, 5),
+      child: ElevatedButton(
+        key: key,
+        style: ElevatedButton.styleFrom(
+          primary: Colors.grey,
+          onPrimary: Colors.white,
+          shape: CircleBorder(),
+          minimumSize: const Size(65, 65),
+        ),
+        onPressed: action,
+        child: Text(
+          text,
+          style: const TextStyle(fontSize: 20),
+        )
+      )
+    );
+  }
+
+}

--- a/forgerock-authenticator/example/lib/widgets/default_button.dart
+++ b/forgerock-authenticator/example/lib/widgets/default_button.dart
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+import 'package:flutter/material.dart';
+
+
+class DefaultButton extends StatelessWidget {
+
+  final VoidCallback action;
+  final String text;
+  final Color color;
+
+  const DefaultButton({Key key, this.action, this.text, this.color}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+        key: key,
+        style: ElevatedButton.styleFrom(
+          primary: color,
+          onPrimary: Colors.white,
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(32.0)),
+          minimumSize: const Size(150, 50),
+        ),
+        onPressed: action,
+        child: Text(
+          text,
+          style: const TextStyle(fontSize: 16),
+        )
+    );
+  }
+
+}

--- a/forgerock-authenticator/example/lib/widgets/notification_box.dart
+++ b/forgerock-authenticator/example/lib/widgets/notification_box.dart
@@ -25,7 +25,7 @@ class NotificationBox extends StatelessWidget {
       child: Stack(
         children: <Widget>[
           Container(
-            padding: const EdgeInsets.only(left: 20, top: 65, right: 20, bottom: 20),
+            padding: const EdgeInsets.all(20),
             decoration: BoxDecoration(
               shape: BoxShape.rectangle,
               color: Colors.white,
@@ -33,21 +33,11 @@ class NotificationBox extends StatelessWidget {
               boxShadow: const [
                 BoxShadow(
                   color: Colors.black,offset: Offset(0,5),
-                  blurRadius: 10
+                  blurRadius: 5
                 ),
               ]
             ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Text('Push Authentication request',
-                  style: const TextStyle(fontSize: 18,fontWeight: FontWeight.w600),textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 15),
-                child,
-                const SizedBox(width: 15),
-              ],
-            ),
+            child: child,
           ),
         ],
       ),

--- a/forgerock-authenticator/example/lib/widgets/notification_dialog.dart
+++ b/forgerock-authenticator/example/lib/widgets/notification_dialog.dart
@@ -8,7 +8,10 @@
 import 'package:flutter/material.dart';
 
 import 'package:forgerock_authenticator/models/push_notification.dart';
+import 'package:forgerock_authenticator/models/push_type.dart';
 
+import 'package:forgerock_authenticator_example/widgets/challenge_button.dart';
+import 'package:forgerock_authenticator_example/widgets/default_button.dart';
 import 'package:forgerock_authenticator_example/widgets/notification_box.dart';
 import 'package:forgerock_authenticator_example/providers/authenticator_provider.dart';
 
@@ -24,71 +27,145 @@ class NotificationDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return NotificationBox(
       child: Column(
+        mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Text('Do you wish to accept sign in from another computer?',
-            style: const TextStyle(fontSize: 14),textAlign: TextAlign.center,
+          Text('Push Authentication request',
+            style: const TextStyle(fontSize: 18,fontWeight: FontWeight.w600),textAlign: TextAlign.center,
           ),
-          const SizedBox(height: 22,),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              ElevatedButton(
-                key: const Key('accept-button'),
-                style: ElevatedButton.styleFrom(
-                  primary: Colors.green,
-                  onPrimary: Colors.white,
-                  shadowColor: Colors.greenAccent,
-                  elevation: 3,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(32.0)),
-                  minimumSize: const Size(120, 40),
-                ),
-                onPressed: () async {
-                  await _approve(true, context);
-                },
-                child: Text(
-                  'Accept',
-                  style: const TextStyle(fontSize: 14),
-                )
-              ),
-              const SizedBox(width: 15),
-              ElevatedButton(
-                key: const Key('reject-button'),
-                style: ElevatedButton.styleFrom(
-                  primary: Colors.red,
-                  onPrimary: Colors.white,
-                  shadowColor: Colors.redAccent,
-                  elevation: 3,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(32.0)),
-                  minimumSize: const Size(120, 40),
-                ),
-                onPressed: () async {
-                  await _approve(false, context);
-                },
-                child: Text(
-                  'Reject',
-                  style: const TextStyle(fontSize: 14),
-                )
-              )
-            ],
-          ),
+          PushType.CHALLENGE.isEqual(pushNotification.pushType)
+              && pushNotification.getNumbersChallenge().isNotEmpty
+          ? _challengeButtons(context)
+          : _defaultButtons(context)
         ])
     );
   }
 
+  Widget _defaultButtons(BuildContext context) {
+    return Column(
+      children: [
+        const SizedBox(height: 30),
+        Text(pushNotification.message != null
+            ? pushNotification.message
+            : 'Do you wish to accept sign in from another device?',
+          style: const TextStyle(fontSize: 16),textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 30),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            DefaultButton(
+              key: const Key('accept-button'),
+              action: () async {
+                await _approve(true, context);
+              },
+              color: Color(0xff006ac8),
+              text: 'Accept',
+            ),
+            const SizedBox(width: 25),
+            DefaultButton(
+              key: const Key('reject-button'),
+              action: () async {
+                await _approve(false, context);
+              },
+              color: Colors.black,
+              text: 'Reject',
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _challengeButtons(BuildContext context) {
+    List<String> challenge = pushNotification.getNumbersChallenge();
+    return Column(
+        children: [
+          const SizedBox(height: 30),
+          Text('To continue with the Sign in, select the number you see on your Other screen',
+            style: const TextStyle(fontSize: 16),textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 30),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ChallengeButton(
+                key: const Key('challenge-option1-button'),
+                action: () async {
+                  await _approveWithChallenge(true, challenge.elementAt(2),
+                      context);
+                },
+                text: challenge.elementAt(0),
+              ),
+              ChallengeButton(
+                key: const Key('challenge-option2-button'),
+                action: () async {
+                  await _approveWithChallenge(true, challenge.elementAt(1),
+                      context);
+                },
+                text: challenge.elementAt(1),
+              ),
+              ChallengeButton(
+                key: const Key('challenge-option3-button'),
+                action: () async {
+                  await _approveWithChallenge(true, challenge.elementAt(2),
+                      context);
+                },
+                text: challenge.elementAt(2),
+              ),
+            ],
+          ),
+          const SizedBox(height: 30),
+          DefaultButton(
+              key: const Key('reject-button'),
+              action: () async {
+                await _approveWithChallenge(false, null,
+                    context);
+              },
+              color: Colors.black,
+              text: 'Reject'
+          ),
+        ]);
+  }
+
   Future<void> _approve(bool approve, BuildContext context) async {
-    final BuildContext rootContext = context.findRootAncestorStateOfType<NavigatorState>().context;
+    final BuildContext rootContext =
+        context.findRootAncestorStateOfType<NavigatorState>().context;
     String message = 'Push Notification successfully processed.';
-    await AuthenticatorProvider.performPushAuthentication(pushNotification, approve)
-      .catchError((Object error) {
+    if(pushNotification.pushType.isEqual(PushType.BIOMETRIC)) {
+      await AuthenticatorProvider.performPushAuthenticationWithBiometric(
+          pushNotification, 'Biometric is required to process this notification', true, approve
+      ).catchError((Object error) {
         message = error.toString();
-      })
-      .then((Object value) {
+      }).then((Object value) {
         _showResult(rootContext, message);
         Navigator.of(rootContext).pop();
       });
+    } else {
+      await AuthenticatorProvider.performPushAuthentication(
+          pushNotification, approve
+      ).catchError((Object error) {
+        message = error.toString();
+      }).then((Object value) {
+        _showResult(rootContext, message);
+        Navigator.of(rootContext).pop();
+      });
+    }
+  }
+
+  Future<void> _approveWithChallenge(
+      bool approve, String challenge, BuildContext context) async {
+    final BuildContext rootContext =
+        context.findRootAncestorStateOfType<NavigatorState>().context;
+    String message = 'Push Notification successfully processed.';
+    await AuthenticatorProvider.performPushAuthenticationWithChallenge(
+            pushNotification, challenge, approve
+    ).catchError((Object error) {
+      message = error.toString();
+    }).then((Object value) {
+      _showResult(rootContext, message);
+      Navigator.of(rootContext).pop();
+    });
   }
 
   void _showResult(BuildContext context, String message) {

--- a/forgerock-authenticator/example/pubspec.yaml
+++ b/forgerock-authenticator/example/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-
   flutter:
     sdk: flutter
 
@@ -22,9 +21,6 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
-  cupertino_icons:
-  flutter_localizations:
-    sdk: flutter
   provider: ^6.0.3
   barcode_scan2: ^4.2.1
 

--- a/forgerock-authenticator/ios/Classes/FRAClientWrapper.swift
+++ b/forgerock-authenticator/ios/Classes/FRAClientWrapper.swift
@@ -272,20 +272,71 @@ open class FRAClientWrapper {
                 }
             }
         } else {
-            pushNotification?.deny {
-                if (result != nil) {
-                    result!(true)
-                }
-            } onError: { (error) in
-                if (result != nil) {
-                    result!(FlutterError(code: "HANDLE_NOTIFICATION_EXCEPTION", message: error.localizedDescription, details: nil))
-                }
-            }
+            denyPushNotification(pushNotification: pushNotification, result: result)
         }
 
         self.updatePendingNotificationsCount()
     }
 
+    func performPushAuthenticationWithChallenge(notificationId: String, challengeResponse: String, accept: Bool, result: FlutterResult?) {
+        let pushNotification = FRAClient.shared?.getNotification(identifier: notificationId)
+
+        if(accept) {
+            pushNotification?.accept(
+            challengeResponse: challengeResponse,
+            onSuccess:{
+                if (result != nil) {
+                    result!(true)
+                }
+            },
+            onError: { (error) in
+                if (result != nil) {
+                    result!(FlutterError(code: "HANDLE_NOTIFICATION_EXCEPTION", message: error.localizedDescription, details: nil))
+                }
+            })
+        } else {
+            denyPushNotification(pushNotification: pushNotification, result: result)
+        }
+
+        self.updatePendingNotificationsCount()
+    }
+    
+    func performPushAuthenticationWithBiometric(notificationId: String, title: String, allowDeviceCredentials: Bool, accept: Bool, result: FlutterResult?) {
+        let pushNotification = FRAClient.shared?.getNotification(identifier: notificationId)
+
+        if(accept) {
+            pushNotification?.accept(
+            title: title,
+            allowDeviceCredentials: allowDeviceCredentials,
+            onSuccess: {
+                if (result != nil) {
+                    result!(true)
+                }
+            },
+            onError: { (error) in
+                if (result != nil) {
+                    result!(FlutterError(code: "HANDLE_NOTIFICATION_EXCEPTION", message: error.localizedDescription, details: nil))
+                }
+            })
+        } else {
+            denyPushNotification(pushNotification: pushNotification, result: result)
+        }
+
+        self.updatePendingNotificationsCount()
+    }
+
+    private func denyPushNotification(pushNotification: PushNotification?, result: FlutterResult?) {
+        pushNotification?.deny {
+            if (result != nil) {
+                result!(true)
+            }
+        } onError: { (error) in
+            if (result != nil) {
+                result!(FlutterError(code: "HANDLE_NOTIFICATION_EXCEPTION", message: error.localizedDescription, details: nil))
+            }
+        }
+    }
+    
     func getPendingNotificationsCount(result: @escaping FlutterResult) {
         result(pendingNotificationsCount())
     }

--- a/forgerock-authenticator/ios/Classes/SwiftForgerockAuthenticatorPlugin.swift
+++ b/forgerock-authenticator/ios/Classes/SwiftForgerockAuthenticatorPlugin.swift
@@ -162,6 +162,35 @@ public class SwiftForgerockAuthenticatorPlugin: NSObject, FlutterPlugin, UNUserN
                 result(FlutterError(code: "PLATAFORM_ARGUMENT_EXCEPTION", message: "iOS could not recognize flutter arguments in method: (performPushAuthentication)", details: nil))
             }
 
+        case "performPushAuthenticationWithChallenge":
+            guard let args = call.arguments else {
+                return
+            }
+            if let myArgs = args as? [String: Any],
+               let accept = myArgs["accept"] as? Bool,
+               let challengeResponse = myArgs["challengeResponse"] as? String,
+               let notificationId = myArgs["notificationId"] as? String {
+
+                FRAClientWrapper.shared.performPushAuthenticationWithChallenge(notificationId: notificationId, challengeResponse: challengeResponse, accept: accept, result: result)
+            } else {
+                result(FlutterError(code: "PLATAFORM_ARGUMENT_EXCEPTION", message: "iOS could not recognize flutter arguments in method: (performPushAuthentication)", details: nil))
+            }
+            
+        case "performPushAuthenticationWithBiometric":
+            guard let args = call.arguments else {
+                return
+            }
+            if let myArgs = args as? [String: Any],
+               let accept = myArgs["accept"] as? Bool,
+               let allowDeviceCredentials = myArgs["allowDeviceCredentials"] as? Bool,
+               let title = myArgs["title"] as? String,
+               let notificationId = myArgs["notificationId"] as? String {
+
+                FRAClientWrapper.shared.performPushAuthenticationWithBiometric(notificationId: notificationId, title: title, allowDeviceCredentials: allowDeviceCredentials, accept: accept, result: result)
+            } else {
+                result(FlutterError(code: "PLATAFORM_ARGUMENT_EXCEPTION", message: "iOS could not recognize flutter arguments in method: (performPushAuthentication)", details: nil))
+            }
+            
         case "getStoredAccount":
             guard let args = call.arguments else {
                 return

--- a/forgerock-authenticator/lib/forgerock_authenticator.dart
+++ b/forgerock-authenticator/lib/forgerock_authenticator.dart
@@ -146,7 +146,7 @@ class ForgerockAuthenticator {
     }
   }
 
-  /// Respond an authentication request from a given [PushNotification] received from OpenAM.
+  /// Respond a [PushType.DEFAULT] authentication request from a given [PushNotification] received from OpenAM.
   static Future<bool?> performPushAuthentication(PushNotification pushNotification, bool accept) async {
     String notificationId = pushNotification.id;
     var params = <String, dynamic>{
@@ -154,6 +154,35 @@ class ForgerockAuthenticator {
       'accept': accept,
     };
     return await _channel.invokeMethod('performPushAuthentication', params);
+  }
+
+  /// Respond a [PushType.CHALLENGE] authentication request from a given [PushNotification] received from OpenAM.
+  ///
+  /// Note: This API is available with OpenAM 7.2 and beyond
+  static Future<bool?> performPushAuthenticationWithChallenge(PushNotification pushNotification,
+      String challengeResponse, bool accept) async {
+    String notificationId = pushNotification.id;
+    var params = <String, dynamic>{
+      'notificationId': notificationId,
+      'challengeResponse': challengeResponse,
+      'accept': accept,
+    };
+    return await _channel.invokeMethod('performPushAuthenticationWithChallenge', params);
+  }
+
+  /// Respond a [PushType.BIOMETRIC] authentication request from a given [PushNotification] received from OpenAM.
+  ///
+  /// Note: This API is available with OpenAM 7.2 and beyond
+  static Future<bool?> performPushAuthenticationWithBiometric(PushNotification pushNotification,
+      String title, bool allowDeviceCredentials, bool accept) async {
+    String notificationId = pushNotification.id;
+    var params = <String, dynamic>{
+      'notificationId': notificationId,
+      'title': title,
+      'allowDeviceCredentials': allowDeviceCredentials,
+      'accept': accept,
+    };
+    return await _channel.invokeMethod('performPushAuthenticationWithBiometric', params);
   }
 
   /// Get all of the notifications that belong to an [Account] object.

--- a/forgerock-authenticator/lib/models/mechanism.dart
+++ b/forgerock-authenticator/lib/models/mechanism.dart
@@ -5,8 +5,6 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-import 'dart:convert';
-
 import 'account.dart';
 import 'push_mechanism.dart';
 import 'oath_mechanism.dart';
@@ -50,7 +48,7 @@ class Mechanism {
       'accountName': accountName,
       'mechanismUID': mechanismUID,
       'type': type,
-      'secret': null
+      'secret': _secret?.replaceRange(0, null, 'REMOVED')
   };
 
   /// Gets the account identification associated with the mechanism.

--- a/forgerock-authenticator/lib/models/push_notification.dart
+++ b/forgerock-authenticator/lib/models/push_notification.dart
@@ -8,6 +8,7 @@
 import 'dart:convert';
 
 import 'push_mechanism.dart';
+import 'push_type.dart';
 
 /// PushNotification is a model class which represents a message that was received from an external
 /// source.
@@ -16,11 +17,16 @@ class PushNotification {
   String? messageId;
   String? challenge;
   String? amlbCookie;
+  String? customPayload;
+  String? message;
+  String? contextInfo;
+  String? numbersChallenge;
   int? timeAdded;
   int? timeExpired;
   int? ttl;
   bool? approved;
   bool? pending;
+  PushType? pushType;
   PushMechanism? _pushMechanism;
 
   /// Creates the PushNotification object with given data.
@@ -29,17 +35,24 @@ class PushNotification {
       this.messageId,
       this.challenge,
       this.amlbCookie,
+      this.customPayload,
+      this.message,
+      this.contextInfo,
+      this.numbersChallenge,
       this.timeAdded,
       this.timeExpired,
       this.ttl,
       this.approved,
-      this.pending);
+      this.pending,
+      this.pushType);
 
   /// Deserializes the specified JSON into an object of the [PushNotification] object.
   factory PushNotification.fromJson(Map<String, dynamic>? json) {
+      String pushType = json?['pushType'] == null ? PushType.DEFAULT.value : json?['pushType'];
       return PushNotification(json?['mechanismUID'],json?['messageId'],json?['challenge'],
-          json?['amlbCookie'],json?['timeAdded'],json?['timeExpired'],json?['ttl'],
-          json?['approved'],json?['pending']
+          json?['amlbCookie'],json?['customPayload'],json?['message'],json?['contextInfo'],
+          json?['numbersChallenge'],json?['timeAdded'],json?['timeExpired'],json?['ttl'],
+          json?['approved'],json?['pending'],pushType.parsePushType()
       );
   }
 
@@ -53,6 +66,24 @@ class PushNotification {
     return _pushMechanism;
   }
 
+  /// Gets the challenge numbers associated with the notification.
+  /// If no challenge numbers are available, return an empty list.
+  List<String>? getNumbersChallenge() {
+    if(numbersChallenge == null) {
+      return List.empty();
+    }
+    return numbersChallenge?.split(',');
+  }
+
+  /// Gets the contextual information associated with the notification.
+  /// If no context information is available, return an empty Map.
+  Map<String, dynamic>? getContextInfo() {
+    if(contextInfo == null) {
+      return Map();
+    }
+    return jsonDecode(contextInfo!);
+  }
+  
   /// Determine if the notification has expired.
   bool isExpired() {
     var now = DateTime.now();
@@ -72,6 +103,10 @@ class PushNotification {
     'ttl': ttl,
     'approved': approved,
     'pending': pending,
+    'customPayload': customPayload,
+    'numbersChallenge': numbersChallenge,
+    'contextInfo': contextInfo,
+    'pushType': pushType?.value,
   };
 
   /// Creates a String representation of [PushNotification] object.

--- a/forgerock-authenticator/lib/models/push_type.dart
+++ b/forgerock-authenticator/lib/models/push_type.dart
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 ForgeRock. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+/// The supported Push types.
+enum PushType {
+  DEFAULT, CHALLENGE, BIOMETRIC
+}
+
+/// Helper extension for PushType.
+extension PushTypeExtension on PushType {
+  /// Return value of PushType.
+  String get value {
+    switch (this) {
+      case PushType.DEFAULT:
+        return "default";
+      case PushType.CHALLENGE:
+        return "challenge";
+      case PushType.BIOMETRIC:
+        return "biometric";
+      default:
+        return "";
+    }
+  }
+
+  /// Compare PushType with given value.
+  bool isEqual(dynamic typeValue) {
+    if (typeValue is String) {
+      return this.toString() == typeValue || this.value == typeValue;
+    } else if (typeValue is PushType) {
+      return this.value == typeValue.value;
+    } else {
+      return false;
+    }
+  }
+}
+
+/// Return PushType for given String value.
+/// If value does not match, returns DEFAULT.
+extension PushTypeParsing on String {
+  PushType parsePushType() {
+    switch (this) {
+      case "default":
+        return PushType.DEFAULT;
+      case "challenge":
+        return PushType.CHALLENGE;
+      case "biometric":
+        return PushType.BIOMETRIC;
+      default:
+        return PushType.DEFAULT;
+    }
+  }
+}

--- a/forgerock-authenticator/pubspec.yaml
+++ b/forgerock-authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: forgerock_authenticator
 description: ForgeRock Authenticator plugin allows you to build the power of the official ForgeRock Authenticator application into your own Flutter app.
-version: 1.0.0
+version: 1.1.0
 homepage: https://www.forgerock.com
 repository: https://github.com/ForgeRock/forgerock-flutter-plugins
 issue_tracker: https://github.com/ForgeRock/forgerock-flutter-plugins/issues

--- a/forgerock-authenticator/test/constants.dart
+++ b/forgerock-authenticator/test/constants.dart
@@ -97,6 +97,38 @@ const String pushNotificationJson = "{" +
     "\"approved\":false," +
     "\"pending\":true}";
 
+const String challengePushNotificationJson = '{'
+    '\"id\":\"0c43c695-8d67-47f1-b575-1c7a83512060-1657238273273\",'
+    '\"mechanismUID\":\"0c43c695-8d67-47f1-b575-1c7a83512060\",'
+    '\"messageId\":\"AUTHENTICATE:2b43a378-0013-4589-8e81-118be10559ac1657238273273\",'
+    '\"message\":\"Login attempt from user0 at ForgeRock-72\",'
+    '\"challenge\":\"23RD41+UyKFZ77Am3Pu5Oxm7L3lu6CB+IhT3ZN4KzQo=\",'
+    '\"amlbCookie\":\"amlbcookie=01\",'
+    '\"timeAdded\":1657238273273,'
+    '\"timeExpired\":1657238393273,'
+    '\"ttl\":120,'
+    '\"approved\":false,\"pending\":true,'
+    '\"customPayload\":\"{  }\",'
+    '\"contextInfo\":\"{ \\"location\\": { \\"latitude\\": 49.2306432, \\"longitude\\": -123.1126528 }, \\"remoteIp\\": \\"192.168.1.1\\", \\"userAgent\\": \\"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/102.0.0.0 Safari\/537.36\\" }\",'
+    '\"pushType\":\"challenge\",'
+    '\"numbersChallenge\":\"27,64,71\"}';
+
+const String biometricPushNotificationJson = '{'
+    '\"id\":\"0c43c695-8d67-47f1-b575-1c7a83512060-1657238273273\",'
+    '\"mechanismUID\":\"0c43c695-8d67-47f1-b575-1c7a83512060\",'
+    '\"messageId\":\"AUTHENTICATE:2b43a378-0013-4589-8e81-118be10559ac1657238273273\",'
+    '\"message\":\"Login attempt from user0 at ForgeRock-72\",'
+    '\"challenge\":\"23RD41+UyKFZ77Am3Pu5Oxm7L3lu6CB+IhT3ZN4KzQo=\",'
+    '\"amlbCookie\":\"amlbcookie=01\",'
+    '\"timeAdded\":1657238273273,'
+    '\"timeExpired\":1657238393273,'
+    '\"ttl\":120,'
+    '\"approved\":false,\"pending\":true,'
+    '\"customPayload\":\"{  }\",'
+    '\"contextInfo\":\"{ \\"location\\": { \\"latitude\\": 49.2306432, \\"longitude\\": -123.1126528 }, \\"remoteIp\\": \\"192.168.1.1\\", \\"userAgent\\": \\"Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/102.0.0.0 Safari\/537.36\\" }\",'
+    '\"pushType\":\"biometric\",'
+    '\"numbersChallenge\":null}';
+
 const String apnsPayload = '{ "aps": { "category": "authentication","messageId": "AUTHENTICATE:63ca6f18-7cfb-4198-bcd0-ac5041fbbea01583798229441","content-available": 1, "interruption-level": "time-sensitive" , "alert": "Login attempt from user1 at issuer1", "sound": "default", "data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJjIjoiRER3cE1EOFlEY2YvSmRaL2pBU3diZFRCNkJBOFhDaEFSNkJTc3hHa2J5ND0iLCJ0IjoiMTIwIiwidSI6IjE4OUNBMDY5LUU0MkQtNEZCQS05QTVELUVCMEYxQkQyOUU0MyIsImwiOiJZVzFzWW1OdmIydHBaVDB3TVE9PSJ9.qcXHvnPrISm58iFt2W_nZPULfDhGz4f4KSidZhNvQHg"}}';
 
 const String oathTokenCodeJson = "{\"oathType\":\"HOTP\",\"code\":\"123456\",\"start\":10000,\"until\":10030}";

--- a/forgerock-authenticator/test/forgerock_authenticator_test.dart
+++ b/forgerock-authenticator/test/forgerock_authenticator_test.dart
@@ -144,6 +144,39 @@ void main() {
     ]);
   });
 
+  test('performPushAuthenticationWithChallenge', () async {
+    final PushNotification notification = PushNotification.fromJson(jsonDecode(challengePushNotificationJson));
+    expect(await ForgerockAuthenticator.performPushAuthenticationWithChallenge(notification, "71", true), isTrue);
+    expect(methodCallLog, hasLength(1));
+    expect(methodCallLog, <Matcher>[
+      isMethodCall(
+        'performPushAuthenticationWithChallenge',
+        arguments: <String, dynamic>{
+          "notificationId": notification.id,
+          "challengeResponse": "71",
+          "accept": true
+        },
+      ),
+    ]);
+  });
+
+  test('performPushAuthenticationWithBiometric', () async {
+    final PushNotification notification = PushNotification.fromJson(jsonDecode(challengePushNotificationJson));
+    expect(await ForgerockAuthenticator.performPushAuthenticationWithBiometric(notification, "Title", true, true), isTrue);
+    expect(methodCallLog, hasLength(1));
+    expect(methodCallLog, <Matcher>[
+      isMethodCall(
+        'performPushAuthenticationWithBiometric',
+        arguments: <String, dynamic>{
+          "notificationId": notification.id,
+          "title": "Title",
+          "allowDeviceCredentials": true,
+          "accept": true
+        },
+      ),
+    ]);
+  });
+
   test('getAllNotifications', () async {
     expect(await ForgerockAuthenticator.getAllNotifications(), List.empty());
     expect(methodCallLog, hasLength(2));
@@ -247,6 +280,10 @@ void setupForgerockAuthenticatorMocks() {
       case 'enableScreenshot':
       case 'disableScreenshot':
       case 'performPushAuthentication':
+        return true;
+      case 'performPushAuthenticationWithChallenge':
+        return true;
+      case 'performPushAuthenticationWithBiometric':
         return true;
       default:
         return null;

--- a/forgerock-authenticator/test/mechanism_test.dart
+++ b/forgerock-authenticator/test/mechanism_test.dart
@@ -60,6 +60,7 @@ void main() {
       expect(jsonMap['accountName'], 'user1');
       expect(jsonMap['issuer'], 'issuer1');
       expect(jsonMap['type'], 'otpauth');
+      expect(jsonMap['secret'], 'REMOVED');
     });
 
     test('returns an JSON representation of the OathMechanism object successfully', () async {

--- a/forgerock-authenticator/test/push_notification_test.dart
+++ b/forgerock-authenticator/test/push_notification_test.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:forgerock_authenticator/models/push_notification.dart';
+import 'package:forgerock_authenticator/models/push_type.dart';
 
 import 'constants.dart';
 
@@ -23,6 +24,50 @@ void main() {
       expect(pushNotification.ttl, 120);
       expect(pushNotification.approved, false);
       expect(pushNotification.pending, true);
+      expect(pushNotification.numbersChallenge, null);
+      expect(pushNotification.contextInfo, null);
+      expect(pushNotification.customPayload, null);
+      expect(pushNotification.pushType, PushType.DEFAULT);
+    });
+
+    test('returns a PushNotification if parse completes successfully for CHALLENGE type', () async {
+      PushNotification pushNotification = PushNotification.fromJson(jsonDecode(challengePushNotificationJson));
+      expect(pushNotification.id, '0c43c695-8d67-47f1-b575-1c7a83512060-1657238273273');
+      expect(pushNotification.mechanismUID, '0c43c695-8d67-47f1-b575-1c7a83512060');
+      expect(pushNotification.messageId, 'AUTHENTICATE:2b43a378-0013-4589-8e81-118be10559ac1657238273273');
+      expect(pushNotification.message, 'Login attempt from user0 at ForgeRock-72');
+      expect(pushNotification.pushType, PushType.CHALLENGE);
+      expect(pushNotification.numbersChallenge, '27,64,71');
+      expect(pushNotification.customPayload, '{  }');
+      expect(pushNotification.contextInfo, '{ "location": { "latitude": 49.2306432, "longitude": -123.1126528 }, "remoteIp": "192.168.1.1", "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36" }');
+    });
+
+    test('returns a PushNotification if parse completes successfully for BIOMETRIC type', () async {
+      PushNotification pushNotification = PushNotification.fromJson(jsonDecode(biometricPushNotificationJson));
+      expect(pushNotification.id, '0c43c695-8d67-47f1-b575-1c7a83512060-1657238273273');
+      expect(pushNotification.mechanismUID, '0c43c695-8d67-47f1-b575-1c7a83512060');
+      expect(pushNotification.messageId, 'AUTHENTICATE:2b43a378-0013-4589-8e81-118be10559ac1657238273273');
+      expect(pushNotification.message, 'Login attempt from user0 at ForgeRock-72');
+      expect(pushNotification.pushType, PushType.BIOMETRIC);
+      expect(pushNotification.numbersChallenge, null);
+      expect(pushNotification.customPayload, '{  }');
+      expect(pushNotification.contextInfo, '{ "location": { "latitude": 49.2306432, "longitude": -123.1126528 }, "remoteIp": "192.168.1.1", "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36" }');
+    });
+
+    test('returns List with number challenges', () async {
+      PushNotification pushNotification = PushNotification.fromJson(jsonDecode(challengePushNotificationJson));
+      expect(pushNotification.getNumbersChallenge()?.elementAt(0), '27');
+      expect(pushNotification.getNumbersChallenge()?.elementAt(1), '64');
+      expect(pushNotification.getNumbersChallenge()?.elementAt(2), '71');
+    });
+
+    test('returns contextual information as a Map', () async {
+      PushNotification pushNotification = PushNotification.fromJson(jsonDecode(challengePushNotificationJson));
+      Map<String, dynamic>? contextInfo = pushNotification.getContextInfo();
+      expect(contextInfo?['remoteIp'], '192.168.1.1');
+      expect(contextInfo?['location']['latitude'], 49.2306432);
+      expect(contextInfo?['location']['longitude'], -123.1126528);
+      expect(contextInfo?['userAgent'], 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36');
     });
 
     test('returns an JSON representation of the PushNotification object successfully', () async {
@@ -72,9 +117,9 @@ void main() {
       expect(pushNotification.isExpired(), false);
     });
 
-    test('returns String representation of the Mechanism', () async {
+    test('returns String representation of the PushNotification', () async {
       PushNotification pushNotification = PushNotification.fromJson(jsonDecode(pushNotificationJson));
-      const String pushNotificationString = '{"id":"0585ace6-6e91-42bb-9a65-2f48f5212a20-100000","mechanismUID":"0585ace6-6e91-42bb-9a65-2f48f5212a20","messageId":"AUTHENTICATE:63ca6f18-7cfb-4198-bcd0-ac5041fbbea01583798229441","challenge":"fZl8wu9JBxdRQ7miq3dE0fbF0Bcdd+gRETUbtl6qSuM=","amlbCookie":"ZnJfc3NvX2FtbGJfcHJvZD0wMQ==","timeAdded":100000,"timeExpired":120000,"ttl":120,"approved":false,"pending":true}';
+      const String pushNotificationString = '{"id":"0585ace6-6e91-42bb-9a65-2f48f5212a20-100000","mechanismUID":"0585ace6-6e91-42bb-9a65-2f48f5212a20","messageId":"AUTHENTICATE:63ca6f18-7cfb-4198-bcd0-ac5041fbbea01583798229441","challenge":"fZl8wu9JBxdRQ7miq3dE0fbF0Bcdd+gRETUbtl6qSuM=","amlbCookie":"ZnJfc3NvX2FtbGJfcHJvZD0wMQ==","timeAdded":100000,"timeExpired":120000,"ttl":120,"approved":false,"pending":true,"customPayload":null,"numbersChallenge":null,"contextInfo":null,"pushType":"default"}';
       expect(pushNotification.toString(), pushNotificationString);
     });
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2033](https://bugster.forgerock.org/jira/browse/SDKS-2033)

# Description

In Android 13 by default the notifications are not enabled and all lower version by default the notifications are enabled. There is a new permission added in Android 13 to receive push notifications - [POST_NOTIFICATIONS](https://developer.android.com/reference/android/Manifest.permission#POST_NOTIFICATIONS).

If your app targets 12L (or lower) and the user taps Don't allow, even just once, they aren't prompted again until one of the following occurs

See more details on this - https://developer.android.com/about/versions/13/changes/notification-permission

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).