### PR TITLE
ForgeRock Flutter Authenticator Plugin 1.1.1 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ These are the available plugins in this repository.
 * ForgeRock Identity Platform
     * Access Management (AM) 6.5.2
 * Android API level 23+
-* iOS 11 and above
+* iOS 12 and above
 * Flutter SDK 2.10.x and above
 
 ## Documentation

--- a/forgerock-authenticator/CHANGELOG.md
+++ b/forgerock-authenticator/CHANGELOG.md
@@ -1,4 +1,10 @@
-# Version 1.1.0
+# Version 1.1.1
+
+## [1.1.1]
+
+#### Updated
+
+- iOS `forgerock-authenticator` dependency to the latest 3.4.1 release.
 
 ## [1.1.0]
 

--- a/forgerock-authenticator/README.md
+++ b/forgerock-authenticator/README.md
@@ -42,7 +42,7 @@ This project is provided as a Flutter plugin, a specialized package that include
 ```groovy
 dependencies:
     dependencies:
-      forgerock_authenticator:^1.1.0
+      forgerock_authenticator:^1.1.1
 ```
 
 ## Getting Started

--- a/forgerock-authenticator/example/android/build.gradle
+++ b/forgerock-authenticator/example/android/build.gradle
@@ -18,7 +18,7 @@ allprojects {
         google()
         mavenCentral()
 
-        //add it to be able to add depency to aar-files from libs folder in build.gradle(yoursAppModule)
+        //add it to be able to add dependency to aar-files from libs folder in build.gradle(yoursAppModule)
         flatDir {
             dirs 'libs'
         }

--- a/forgerock-authenticator/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/forgerock-authenticator/example/ios/Runner.xcodeproj/project.pbxproj
@@ -492,7 +492,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/RunnerProfile.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 140;
+				CURRENT_PROJECT_VERSION = 141;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "Runner/Info-Debug.plist";
@@ -501,7 +501,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.authenticator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -719,7 +719,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/RunnerDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 140;
+				CURRENT_PROJECT_VERSION = 141;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "Runner/Info-Debug.plist";
@@ -728,7 +728,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.authenticator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -749,7 +749,7 @@
 				CODE_SIGN_ENTITLEMENTS = Runner/RunnerRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 140;
+				CURRENT_PROJECT_VERSION = 141;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = "Runner/Info-Release.plist";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.authenticator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/forgerock-authenticator/example/pubspec.yaml
+++ b/forgerock-authenticator/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: forgerock_authenticator_example
 description: Demonstrates how to use the forgerock_authenticator plugin.
-version: 1.1.0
+version: 1.1.1
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.

--- a/forgerock-authenticator/ios/forgerock_authenticator.podspec
+++ b/forgerock-authenticator/ios/forgerock_authenticator.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'forgerock_authenticator'
-  s.version          = '1.0.0'
+  s.version          = '1.1.1'
   s.summary          = 'ForgeRock Authenticator Plugin'
   s.description      = <<-DESC
   ForgeRock Authenticator plugin allows you to build the power of the official ForgeRock Authenticator application into your own Flutter app.
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'FRAuthenticator', '3.4.0'
+  s.dependency 'FRAuthenticator', '3.4.1'
 
   s.platform = :ios, '12.0'
 

--- a/forgerock-authenticator/lib/exception/exceptions.dart
+++ b/forgerock-authenticator/lib/exception/exceptions.dart
@@ -9,7 +9,8 @@
 class DuplicateMechanismException implements Exception {
   late String _message;
 
-  DuplicateMechanismException([String message = 'This authentication method is already registered.']) {
+  DuplicateMechanismException(
+      [String message = 'This authentication method is already registered.']) {
     this._message = message;
   }
 
@@ -24,7 +25,7 @@ class MechanismCreationException implements Exception {
   late String _message;
 
   MechanismCreationException([String? message]) {
-    if(message != null) {
+    if (message != null) {
       this._message = 'Error registering new MFA account:\n $message';
     } else {
       this._message = 'Error registering new MFA account.';
@@ -42,8 +43,9 @@ class HandleNotificationException implements Exception {
   late String _message;
 
   HandleNotificationException([String? message]) {
-    if(message != null) {
-      this._message = 'Error processing Push Authentication request:\n $message';
+    if (message != null) {
+      this._message =
+          'Error processing Push Authentication request:\n $message';
     } else {
       this._message = 'Error processing Push Authentication request.';
     }

--- a/forgerock-authenticator/lib/forgerock_authenticator.dart
+++ b/forgerock-authenticator/lib/forgerock_authenticator.dart
@@ -20,9 +20,10 @@ import 'models/push_notification.dart';
 /// Mobile SDK. It is the front facing class where the methods available in the SDK can be
 /// found and utilized.
 class ForgerockAuthenticator {
-
-  static const MethodChannel _channel = MethodChannel('forgerock_authenticator');
-  static const EventChannel _eventChannel = EventChannel('forgerock_authenticator/events');
+  static const MethodChannel _channel =
+      MethodChannel('forgerock_authenticator');
+  static const EventChannel _eventChannel =
+      EventChannel('forgerock_authenticator/events');
 
   static const AccountParsingException = 'ACCOUNT_PARSING_EXCEPTION';
   static const AuthenticatorException = 'AUTHENTICATOR_EXCEPTION';
@@ -67,16 +68,15 @@ class ForgerockAuthenticator {
   static Future<List<Account>> getAllAccounts() async {
     try {
       List? list = await _channel.invokeMethod('getAllAccounts');
-      if(list != null && list.isNotEmpty) {
+      if (list != null && list.isNotEmpty) {
         List<Account> accounts = [];
-        for(final element in list) {
+        for (final element in list) {
           accounts.add(Account.fromJson(_getPlatformData(element)));
         }
         return accounts;
       } else {
         return List.empty();
       }
-
     } on PlatformException catch (ex) {
       throw ex;
     }
@@ -120,12 +120,13 @@ class ForgerockAuthenticator {
 
   /// Get the [PushNotification] object with its id. Identifier of PushNotification object is "<mechanismUUID>-<timeAdded>"
   /// Returns `null` if the notification could not be found.
-  static Future<PushNotification?> getNotification(String notificationId) async {
+  static Future<PushNotification?> getNotification(
+      String notificationId) async {
     var params = <String, dynamic>{
       'notificationId': notificationId,
     };
     var notification = await _channel.invokeMethod('getNotification', params);
-    if(notification != null) {
+    if (notification != null) {
       return PushNotification.fromJson(_getPlatformData(notification));
     } else {
       return null;
@@ -134,12 +135,13 @@ class ForgerockAuthenticator {
 
   /// Receives an APNS or FCM remote message and covert into a [PushNotification] object,
   /// which allows accept or deny Push Authentication requests.
-  static Future<PushNotification?> handleMessageWithPayload(Map<String, dynamic> userInfo) async {
+  static Future<PushNotification?> handleMessageWithPayload(
+      Map<String, dynamic> userInfo) async {
     var params = <String, dynamic>{
       'userInfo': userInfo,
     };
     var json = await _channel.invokeMethod('handleMessageWithPayload', params);
-    if(json != null) {
+    if (json != null) {
       return PushNotification.fromJson(_getPlatformData(json));
     } else {
       return null;
@@ -147,7 +149,8 @@ class ForgerockAuthenticator {
   }
 
   /// Respond a [PushType.DEFAULT] authentication request from a given [PushNotification] received from OpenAM.
-  static Future<bool?> performPushAuthentication(PushNotification pushNotification, bool accept) async {
+  static Future<bool?> performPushAuthentication(
+      PushNotification pushNotification, bool accept) async {
     String notificationId = pushNotification.id;
     var params = <String, dynamic>{
       'notificationId': notificationId,
@@ -159,22 +162,28 @@ class ForgerockAuthenticator {
   /// Respond a [PushType.CHALLENGE] authentication request from a given [PushNotification] received from OpenAM.
   ///
   /// Note: This API is available with OpenAM 7.2 and beyond
-  static Future<bool?> performPushAuthenticationWithChallenge(PushNotification pushNotification,
-      String challengeResponse, bool accept) async {
+  static Future<bool?> performPushAuthenticationWithChallenge(
+      PushNotification pushNotification,
+      String challengeResponse,
+      bool accept) async {
     String notificationId = pushNotification.id;
     var params = <String, dynamic>{
       'notificationId': notificationId,
       'challengeResponse': challengeResponse,
       'accept': accept,
     };
-    return await _channel.invokeMethod('performPushAuthenticationWithChallenge', params);
+    return await _channel.invokeMethod(
+        'performPushAuthenticationWithChallenge', params);
   }
 
   /// Respond a [PushType.BIOMETRIC] authentication request from a given [PushNotification] received from OpenAM.
   ///
   /// Note: This API is available with OpenAM 7.2 and beyond
-  static Future<bool?> performPushAuthenticationWithBiometric(PushNotification pushNotification,
-      String title, bool allowDeviceCredentials, bool accept) async {
+  static Future<bool?> performPushAuthenticationWithBiometric(
+      PushNotification pushNotification,
+      String title,
+      bool allowDeviceCredentials,
+      bool accept) async {
     String notificationId = pushNotification.id;
     var params = <String, dynamic>{
       'notificationId': notificationId,
@@ -182,27 +191,29 @@ class ForgerockAuthenticator {
       'allowDeviceCredentials': allowDeviceCredentials,
       'accept': accept,
     };
-    return await _channel.invokeMethod('performPushAuthenticationWithBiometric', params);
+    return await _channel.invokeMethod(
+        'performPushAuthenticationWithBiometric', params);
   }
 
   /// Get all of the notifications that belong to an [Account] object.
   /// Returns `null` if no [PushNotification] could be found or the accountId is invalid.
-  static Future<List<PushNotification>> getAllNotificationsByAccountId(String accountId) async {
+  static Future<List<PushNotification>> getAllNotificationsByAccountId(
+      String accountId) async {
     var params = <String, dynamic>{
       'accountId': accountId,
     };
     try {
       List? list = await _channel.invokeMethod('getAllNotifications', params);
-      if(list != null && list.isNotEmpty) {
+      if (list != null && list.isNotEmpty) {
         List<PushNotification> notifications = [];
-        for(final element in list) {
-          notifications.add(PushNotification.fromJson(_getPlatformData(element)));
+        for (final element in list) {
+          notifications
+              .add(PushNotification.fromJson(_getPlatformData(element)));
         }
         return notifications;
       } else {
         return List.empty();
       }
-
     } on PlatformException catch (ex) {
       throw ex;
     }
@@ -210,7 +221,8 @@ class ForgerockAuthenticator {
 
   /// Get the number of non-expired notifications across all mechanisms.
   static Future<int> getPendingNotificationsCount() async {
-    final int count = await _channel.invokeMethod('getPendingNotificationsCount');
+    final int count =
+        await _channel.invokeMethod('getPendingNotificationsCount');
     return count;
   }
 
@@ -218,16 +230,19 @@ class ForgerockAuthenticator {
   /// Returns `null` if no [PushNotification] could be found.
   static Future<List<PushNotification>> getAllNotifications() async {
     try {
-      var mechanismMap = await _channel.invokeMethod('getAllMechanismsGroupByUID');
+      var mechanismMap =
+          await _channel.invokeMethod('getAllMechanismsGroupByUID');
       List? list = await _channel.invokeMethod('getAllNotifications');
-      if(list != null && list.isNotEmpty) {
+      if (list != null && list.isNotEmpty) {
         List<PushNotification> notifications = [];
-        for(final element in list) {
-          PushNotification pushNotification = PushNotification.fromJson(_getPlatformData(element));
-          if(mechanismMap.isNotEmpty) {
+        for (final element in list) {
+          PushNotification pushNotification =
+              PushNotification.fromJson(_getPlatformData(element));
+          if (mechanismMap.isNotEmpty) {
             final mechanismJson = mechanismMap[pushNotification.mechanismUID];
-            if(mechanismJson != null) {
-              final pushMechanism = Mechanism.fromJson(_getPlatformData(mechanismJson));
+            if (mechanismJson != null) {
+              final pushMechanism =
+                  Mechanism.fromJson(_getPlatformData(mechanismJson));
               pushNotification.setMechanism(pushMechanism as PushMechanism?);
               notifications.add(pushNotification);
             }
@@ -237,19 +252,18 @@ class ForgerockAuthenticator {
       } else {
         return List.empty();
       }
-
     } on PlatformException catch (ex) {
       throw ex;
     }
   }
-
 
   //
   // App helper methods
   //
 
   /// Indicates if the app was ever launched before.
-  static Future<bool?> hasAlreadyLaunched() =>  _channel.invokeMethod<bool?>('hasAlreadyLaunched');
+  static Future<bool?> hasAlreadyLaunched() =>
+      _channel.invokeMethod<bool?>('hasAlreadyLaunched');
 
   /// Disable screenshoot capture on Android devices.
   static Future<bool?> disableScreenshot() async {
@@ -275,21 +289,21 @@ class ForgerockAuthenticator {
   }
 
   static _getPlatformData(element) {
-    if(element == null) {
+    if (element == null) {
       return null;
-    } else if(element is String) {
+    } else if (element is String) {
       return jsonDecode(element);
     } else {
       return Map<String, dynamic>.from(element);
     }
   }
 
-
   //
   // Deep Link methods
   //
 
-  static Future<String?> getInitialLink() =>  _channel.invokeMethod<String?>('getInitialLink');
+  static Future<String?> getInitialLink() =>
+      _channel.invokeMethod<String?>('getInitialLink');
 
   static late final Stream<String?> linkStream = _eventChannel
       .receiveBroadcastStream()
@@ -312,5 +326,4 @@ class ForgerockAuthenticator {
       },
     ),
   );
-
 }

--- a/forgerock-authenticator/lib/forgerock_push_connector.dart
+++ b/forgerock-authenticator/lib/forgerock_push_connector.dart
@@ -11,7 +11,6 @@ import 'package:flutter/services.dart';
 /// The [ForgerockPushConnector] fires notifications whenever an APNS/FCM token
 /// are generated and a remote message is received.
 class ForgerockPushConnector {
-
   final MethodChannel _channel = const MethodChannel('forgerock_authenticator');
 
   /// Last pending push message.
@@ -50,5 +49,4 @@ class ForgerockPushConnector {
         throw UnsupportedError('Unrecognized JSON message');
     }
   }
-
 }

--- a/forgerock-authenticator/lib/models/account.dart
+++ b/forgerock-authenticator/lib/models/account.dart
@@ -26,21 +26,31 @@ class Account {
   List<Mechanism>? mechanismList;
 
   /// Creates Account object with given information.
-  Account(this.id, this.issuer, this.displayIssuer, this.accountName, this.displayAccountName,
-      this.imageURL, this.backgroundColor, this.timeAdded, [this.mechanismList]);
+  Account(
+      this.id,
+      this.issuer,
+      this.displayIssuer,
+      this.accountName,
+      this.displayAccountName,
+      this.imageURL,
+      this.backgroundColor,
+      this.timeAdded,
+      [this.mechanismList]);
 
   /// Deserializes the specified Json into an object of the [Account] object.
   /// This account object may include a list of [Mechanism]
   factory Account.fromJson(Map<String, dynamic> json) {
     Account account = Account(
-        json['id'],  json['issuer'], json['displayIssuer'],
-        json['accountName'], json['displayAccountName'],
+        json['id'],
+        json['issuer'],
+        json['displayIssuer'],
+        json['accountName'],
+        json['displayAccountName'],
         json['imageURL'] == 'null' ? null : json['imageURL'],
         json['backgroundColor'] == 'null' ? null : json['backgroundColor'],
-        json['timeAdded']
-    );
+        json['timeAdded']);
 
-    if(json['mechanismList'] != null) {
+    if (json['mechanismList'] != null) {
       List? toParseList;
       if (json['mechanismList'] is String) {
         toParseList = jsonDecode(json['mechanismList']);
@@ -50,9 +60,9 @@ class Account {
 
       List<Mechanism> mechanismList = [];
       for (final element in toParseList!) {
-        if(element is String) {
+        if (element is String) {
           mechanismList.add(Mechanism.fromJson(jsonDecode(element), account));
-        } else  if (element is Map<String, dynamic>) {
+        } else if (element is Map<String, dynamic>) {
           mechanismList.add(Mechanism.fromJson(element, account));
         } else {
           var tmp = Map<String, dynamic>.from(element);
@@ -68,7 +78,7 @@ class Account {
   /// Creates a JSON string representation of [Account] object.
   Map<String, dynamic> toJson() {
     List<String> list = [];
-    if(mechanismList != null) {
+    if (mechanismList != null) {
       for (final element in mechanismList!) {
         list.add(jsonEncode(element.toJson()));
       }
@@ -89,7 +99,9 @@ class Account {
 
   /// Gets the name of the IDP that issued this account.
   String? getIssuer() {
-    if(this.displayIssuer != "null" && this.displayIssuer != null && this.displayIssuer!.isNotEmpty) {
+    if (this.displayIssuer != "null" &&
+        this.displayIssuer != null &&
+        this.displayIssuer!.isNotEmpty) {
       return this.displayIssuer;
     } else {
       return this.issuer;
@@ -98,7 +110,9 @@ class Account {
 
   /// Gets the name of the account.
   String? getAccountName() {
-    if(this.displayAccountName != "null" &&  this.displayAccountName != null && this.displayAccountName!.isNotEmpty) {
+    if (this.displayAccountName != "null" &&
+        this.displayAccountName != null &&
+        this.displayAccountName!.isNotEmpty) {
       return this.displayAccountName;
     } else {
       return this.accountName;
@@ -107,12 +121,12 @@ class Account {
 
   /// Gets the [OathMechanism] associated with this account.
   OathMechanism? getOathMechanism() {
-    if(mechanismList == null) {
+    if (mechanismList == null) {
       return null;
     }
 
-    for(Mechanism mechanism in mechanismList!) {
-      if(mechanism.type == Mechanism.OATH) {
+    for (Mechanism mechanism in mechanismList!) {
+      if (mechanism.type == Mechanism.OATH) {
         return mechanism as OathMechanism?;
       }
     }
@@ -126,12 +140,12 @@ class Account {
 
   /// Gets the [PushMechanism] associated with this account.
   PushMechanism? getPushMechanism() {
-    if(mechanismList == null) {
+    if (mechanismList == null) {
       return null;
     }
 
-    for(Mechanism mechanism in mechanismList!) {
-      if(mechanism.type == Mechanism.PUSH) {
+    for (Mechanism mechanism in mechanismList!) {
+      if (mechanism.type == Mechanism.PUSH) {
         return mechanism as PushMechanism?;
       }
     }
@@ -150,5 +164,4 @@ class Account {
 
   /// Creates a String representation of [Account] object.
   String toString() => jsonEncode(toJson());
-
 }

--- a/forgerock-authenticator/lib/models/mechanism.dart
+++ b/forgerock-authenticator/lib/models/mechanism.dart
@@ -25,7 +25,8 @@ class Mechanism {
   /// The Mechanism model represents the two-factor way used for authentication.
   /// Encapsulates the related settings, as well as an owning Account.
   Mechanism(this.id, this.mechanismUID, this.issuer, this.accountName,
-      this.type, this._secret, this.timeAdded, [this.account]);
+      this.type, this._secret, this.timeAdded,
+      [this.account]);
 
   /// Deserializes the specified Json into an object of the [Mechanism] object.
   factory Mechanism.fromJson(Map<String, dynamic> json, [Account? account]) {
@@ -34,22 +35,27 @@ class Mechanism {
     } else if (json['type'] == OATH) {
       return OathMechanism.fromJson(json, account);
     } else {
-      return Mechanism(json['id'],json['mechanismUID'],json['issuer'],
-          json['accountName'],json['type'],json['secret'],json['timeAdded'],
-          account
-      );
+      return Mechanism(
+          json['id'],
+          json['mechanismUID'],
+          json['issuer'],
+          json['accountName'],
+          json['type'],
+          json['secret'],
+          json['timeAdded'],
+          account);
     }
   }
 
   /// Creates a JSON string representation of [Mechanism] object.
   Map<String, dynamic> toJson() => {
-      'id': id,
-      'issuer': issuer,
-      'accountName': accountName,
-      'mechanismUID': mechanismUID,
-      'type': type,
-      'secret': _secret?.replaceRange(0, null, 'REMOVED')
-  };
+        'id': id,
+        'issuer': issuer,
+        'accountName': accountName,
+        'mechanismUID': mechanismUID,
+        'type': type,
+        'secret': _secret?.replaceRange(0, null, 'REMOVED')
+      };
 
   /// Gets the account identification associated with the mechanism.
   String getAccountId() {
@@ -65,6 +71,4 @@ class Mechanism {
   Account? getAccount() {
     return this.account;
   }
-
 }
-

--- a/forgerock-authenticator/lib/models/oath_mechanism.dart
+++ b/forgerock-authenticator/lib/models/oath_mechanism.dart
@@ -10,9 +10,7 @@ import 'dart:convert';
 import 'account.dart';
 import 'mechanism.dart';
 
-enum TokenType {
-  HOTP, TOTP
-}
+enum TokenType { HOTP, TOTP }
 
 /// Represents an instance of a OATH authentication mechanism. Associated with an [Account].
 class OathMechanism extends Mechanism {
@@ -23,10 +21,22 @@ class OathMechanism extends Mechanism {
   int? period;
 
   /// Creates [OathMechanism] object with given information.
-  OathMechanism(String? id, String? mechanismUID, String? issuer, String? accountName,
-      String? type, TokenType oathType, String? algorithm, String? secret, int? digits,
-      int? counter, int? period, int? timeAdded, [Account? account]) :
-        super(id, mechanismUID, issuer,  accountName, type, secret, timeAdded, account) {
+  OathMechanism(
+      String? id,
+      String? mechanismUID,
+      String? issuer,
+      String? accountName,
+      String? type,
+      TokenType oathType,
+      String? algorithm,
+      String? secret,
+      int? digits,
+      int? counter,
+      int? period,
+      int? timeAdded,
+      [Account? account])
+      : super(id, mechanismUID, issuer, accountName, type, secret, timeAdded,
+            account) {
     this.oathType = oathType;
     this.algorithm = algorithm;
     this.digits = digits;
@@ -35,41 +45,48 @@ class OathMechanism extends Mechanism {
   }
 
   /// Deserializes the specified Json into an object of the [OathMechanism] object.
-  factory OathMechanism.fromJson(Map<String, dynamic> json, [Account? account]) {
+  factory OathMechanism.fromJson(Map<String, dynamic> json,
+      [Account? account]) {
     return OathMechanism(
         json['id'],
         json['mechanismUID'],
         json['issuer'],
         json['accountName'],
         json['type'],
-        json['oathType'].toUpperCase() == 'HOTP' ? TokenType.HOTP : TokenType.TOTP,
+        json['oathType'].toUpperCase() == 'HOTP'
+            ? TokenType.HOTP
+            : TokenType.TOTP,
         json['algorithm'],
         json['secret'],
-        json['digits'] is String ? int.tryParse(json['digits']) : json['digits'],
-        json['counter'] is String ? int.tryParse(json['counter']) : json['counter'],
-        json['period'] is String ? int.tryParse(json['period']) : json['period'],
+        json['digits'] is String
+            ? int.tryParse(json['digits'])
+            : json['digits'],
+        json['counter'] is String
+            ? int.tryParse(json['counter'])
+            : json['counter'],
+        json['period'] is String
+            ? int.tryParse(json['period'])
+            : json['period'],
         json['timeAdded'],
-        account
-    );
+        account);
   }
 
   /// Creates a JSON string representation of [OathMechanism] object.
   Map<String, dynamic> toJson() => {
-      'id': id,
-      'issuer': issuer,
-      'accountName': accountName,
-      'mechanismUID': mechanismUID,
-      'oathType': oathType == TokenType.HOTP ? 'HOTP' : 'TOTP',
-      'type': 'otpauth',
-      'algorithm': algorithm,
-      'secret': 'REMOVED',
-      'digits': digits,
-      'counter': counter,
-      'period': period,
-      'timeAdded': timeAdded
-  };
+        'id': id,
+        'issuer': issuer,
+        'accountName': accountName,
+        'mechanismUID': mechanismUID,
+        'oathType': oathType == TokenType.HOTP ? 'HOTP' : 'TOTP',
+        'type': 'otpauth',
+        'algorithm': algorithm,
+        'secret': 'REMOVED',
+        'digits': digits,
+        'counter': counter,
+        'period': period,
+        'timeAdded': timeAdded
+      };
 
   /// Creates a String representation of [OathMechanism] object.
   String toString() => jsonEncode(toJson());
-
 }

--- a/forgerock-authenticator/lib/models/oath_token_code.dart
+++ b/forgerock-authenticator/lib/models/oath_token_code.dart
@@ -27,20 +27,21 @@ class OathTokenCode {
   /// Deserializes the specified JSON into an [OathTokenCode] object.
   factory OathTokenCode.fromJson(Map<String, dynamic>? json) {
     String type = json?['oathType'];
-    var oathType = type.toUpperCase() == 'HOTP' ? TokenType.HOTP : TokenType.TOTP;
+    var oathType =
+        type.toUpperCase() == 'HOTP' ? TokenType.HOTP : TokenType.TOTP;
 
-    return OathTokenCode(json?['code'], json?['start'], json?['until'], oathType);
+    return OathTokenCode(
+        json?['code'], json?['start'], json?['until'], oathType);
   }
 
   /// Creates a JSON string representation of [OathTokenCode] object.
   Map<String, dynamic> toJson() => {
-    'code': code,
-    'start': start,
-    'until': until,
-    'oathType': oathType == TokenType.HOTP ? 'HOTP' : 'TOTP'
-  };
+        'code': code,
+        'start': start,
+        'until': until,
+        'oathType': oathType == TokenType.HOTP ? 'HOTP' : 'TOTP'
+      };
 
   /// Creates a String representation of [OathTokenCode] object.
   String toString() => jsonEncode(toJson());
-
 }

--- a/forgerock-authenticator/lib/models/push_mechanism.dart
+++ b/forgerock-authenticator/lib/models/push_mechanism.dart
@@ -12,39 +12,55 @@ import 'mechanism.dart';
 
 /// Represents an instance of a Push authentication mechanism. Associated with an [Account].
 class PushMechanism extends Mechanism {
-
   String? registrationEndpoint;
   String? authenticationEndpoint;
 
   /// Creates [PushMechanism] object with given information.
-  PushMechanism(String? id, String? mechanismUID, String? issuer, String? accountName,
-      String? type, String? secret, String? registrationEndpoint, String? authenticationEndpoint,
-      int? timeAdded, [Account? account]) : super(id, mechanismUID, issuer, accountName, type, secret, timeAdded, account) {
+  PushMechanism(
+      String? id,
+      String? mechanismUID,
+      String? issuer,
+      String? accountName,
+      String? type,
+      String? secret,
+      String? registrationEndpoint,
+      String? authenticationEndpoint,
+      int? timeAdded,
+      [Account? account])
+      : super(id, mechanismUID, issuer, accountName, type, secret, timeAdded,
+            account) {
     this.authenticationEndpoint = authenticationEndpoint;
     this.registrationEndpoint = registrationEndpoint;
   }
 
   /// Deserializes the specified Json into an object of the [PushMechanism] object.
-  factory PushMechanism.fromJson(Map<String, dynamic> json, [Account? account]) {
-    return PushMechanism(json['id'],json['mechanismUID'],json['issuer'],
-        json['accountName'],json['type'],json['secret'],json['registrationEndpoint'],
-        json['authenticationEndpoint'],json['timeAdded'], account
-    );
+  factory PushMechanism.fromJson(Map<String, dynamic> json,
+      [Account? account]) {
+    return PushMechanism(
+        json['id'],
+        json['mechanismUID'],
+        json['issuer'],
+        json['accountName'],
+        json['type'],
+        json['secret'],
+        json['registrationEndpoint'],
+        json['authenticationEndpoint'],
+        json['timeAdded'],
+        account);
   }
 
   /// Creates a JSON string representation of [PushMechanism] object.
   Map<String, dynamic> toJson() => {
-      'id': id,
-      'issuer': issuer,
-      'accountName': accountName,
-      'mechanismUID': mechanismUID,
-      'type': 'pushauth',
-      'secret': 'REMOVED',
-      'authenticationEndpoint': authenticationEndpoint,
-      'registrationEndpoint': null,
-  };
+        'id': id,
+        'issuer': issuer,
+        'accountName': accountName,
+        'mechanismUID': mechanismUID,
+        'type': 'pushauth',
+        'secret': 'REMOVED',
+        'authenticationEndpoint': authenticationEndpoint,
+        'registrationEndpoint': null,
+      };
 
   /// Creates a String representation of [PushMechanism] object.
   String toString() => jsonEncode(toJson());
-
 }

--- a/forgerock-authenticator/lib/models/push_notification.dart
+++ b/forgerock-authenticator/lib/models/push_notification.dart
@@ -48,12 +48,23 @@ class PushNotification {
 
   /// Deserializes the specified JSON into an object of the [PushNotification] object.
   factory PushNotification.fromJson(Map<String, dynamic>? json) {
-      String pushType = json?['pushType'] == null ? PushType.DEFAULT.value : json?['pushType'];
-      return PushNotification(json?['mechanismUID'],json?['messageId'],json?['challenge'],
-          json?['amlbCookie'],json?['customPayload'],json?['message'],json?['contextInfo'],
-          json?['numbersChallenge'],json?['timeAdded'],json?['timeExpired'],json?['ttl'],
-          json?['approved'],json?['pending'],pushType.parsePushType()
-      );
+    String pushType =
+        json?['pushType'] == null ? PushType.DEFAULT.value : json?['pushType'];
+    return PushNotification(
+        json?['mechanismUID'],
+        json?['messageId'],
+        json?['challenge'],
+        json?['amlbCookie'],
+        json?['customPayload'],
+        json?['message'],
+        json?['contextInfo'],
+        json?['numbersChallenge'],
+        json?['timeAdded'],
+        json?['timeExpired'],
+        json?['ttl'],
+        json?['approved'],
+        json?['pending'],
+        pushType.parsePushType());
   }
 
   /// Sets the mechanism object associated with the notification.
@@ -69,7 +80,7 @@ class PushNotification {
   /// Gets the challenge numbers associated with the notification.
   /// If no challenge numbers are available, return an empty list.
   List<String>? getNumbersChallenge() {
-    if(numbersChallenge == null) {
+    if (numbersChallenge == null) {
       return List.empty();
     }
     return numbersChallenge?.split(',');
@@ -78,12 +89,12 @@ class PushNotification {
   /// Gets the contextual information associated with the notification.
   /// If no context information is available, return an empty Map.
   Map<String, dynamic>? getContextInfo() {
-    if(contextInfo == null) {
+    if (contextInfo == null) {
       return Map();
     }
     return jsonDecode(contextInfo!);
   }
-  
+
   /// Determine if the notification has expired.
   bool isExpired() {
     var now = DateTime.now();
@@ -93,21 +104,21 @@ class PushNotification {
 
   /// Creates a JSON string representation of [PushNotification] object.
   Map<String, dynamic> toJson() => {
-    'id': '$mechanismUID-$timeAdded',
-    'mechanismUID': mechanismUID,
-    'messageId': messageId,
-    'challenge': challenge,
-    'amlbCookie': amlbCookie,
-    'timeAdded': timeAdded,
-    'timeExpired': timeExpired,
-    'ttl': ttl,
-    'approved': approved,
-    'pending': pending,
-    'customPayload': customPayload,
-    'numbersChallenge': numbersChallenge,
-    'contextInfo': contextInfo,
-    'pushType': pushType?.value,
-  };
+        'id': '$mechanismUID-$timeAdded',
+        'mechanismUID': mechanismUID,
+        'messageId': messageId,
+        'challenge': challenge,
+        'amlbCookie': amlbCookie,
+        'timeAdded': timeAdded,
+        'timeExpired': timeExpired,
+        'ttl': ttl,
+        'approved': approved,
+        'pending': pending,
+        'customPayload': customPayload,
+        'numbersChallenge': numbersChallenge,
+        'contextInfo': contextInfo,
+        'pushType': pushType?.value,
+      };
 
   /// Creates a String representation of [PushNotification] object.
   String toString() => jsonEncode(toJson());
@@ -116,5 +127,4 @@ class PushNotification {
   String get id {
     return '$mechanismUID-$timeAdded';
   }
-
 }

--- a/forgerock-authenticator/lib/models/push_type.dart
+++ b/forgerock-authenticator/lib/models/push_type.dart
@@ -6,9 +6,7 @@
  */
 
 /// The supported Push types.
-enum PushType {
-  DEFAULT, CHALLENGE, BIOMETRIC
-}
+enum PushType { DEFAULT, CHALLENGE, BIOMETRIC }
 
 /// Helper extension for PushType.
 extension PushTypeExtension on PushType {

--- a/forgerock-authenticator/pubspec.yaml
+++ b/forgerock-authenticator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: forgerock_authenticator
 description: ForgeRock Authenticator plugin allows you to build the power of the official ForgeRock Authenticator application into your own Flutter app.
-version: 1.1.0
+version: 1.1.1
 homepage: https://www.forgerock.com
 repository: https://github.com/ForgeRock/forgerock-flutter-plugins
 issue_tracker: https://github.com/ForgeRock/forgerock-flutter-plugins/issues


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2203](https://bugster.forgerock.org/jira/browse/SDKS-2203) ForgeRock Flutter Authenticator Plugin 1.1.1 Release

# Description

- Updated the authenticator plugin to use the latest iOS SDK version 3.4.1
- Ran `flutter format .` as suggested by pub.dev, with hope to resolve the 10 penalty points in the [package score](https://pub.dev/packages/forgerock_authenticator/score)
- Other minor fixes like typos and version numbers

# Definition of Done Checklist:

- [x] Acceptance criteria is met.
- [x] Change log updated.

I also performed a quick sanity test of the example app included with the plugin and confirmed that it works well both on iOS and Android devices. 