### PR TITLE
Updated iOS and Android dependencies to 4.1.0-beta1 release (#21)

### DIFF
--- a/forgerock-authenticator/CHANGELOG.md
+++ b/forgerock-authenticator/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Updated
 
-- Android and iOS `forgerock-authenticator` dependency to the 4.0.0 release
+- Android and iOS `forgerock-authenticator` dependency to the 4.1.0-beta1 release
 - Sample app updated to use the new Authenticator policies feature
 
 ## [1.1.2]

--- a/forgerock-authenticator/android/build.gradle
+++ b/forgerock-authenticator/android/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging:23.1.2'
     implementation 'com.google.android.gms:play-services-location:21.0.1'
 
-    implementation 'org.forgerock:forgerock-authenticator:4.0.0'
-    implementation 'org.forgerock:forgerock-core:4.0.0'
+    implementation 'org.forgerock:forgerock-authenticator:4.1.0-beta1'
+    implementation 'org.forgerock:forgerock-core:4.1.0-beta1'
 
     //add lib via aar-depency
 //    implementation(name: 'forgerock-authenticator-debug', ext: 'aar')

--- a/forgerock-authenticator/ios/forgerock_authenticator.podspec
+++ b/forgerock-authenticator/ios/forgerock_authenticator.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.platform = :ios, '12.0'
   s.dependency 'Flutter'
-  s.dependency 'FRAuthenticator', '4.0.0'
+  s.dependency 'FRAuthenticator', '4.1.0-beta1'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2519](https://bugster.forgerock.org/jira/browse/SDKS-2519) Update and release version 1.2.0 of the forgerock_authenticator plugin

# Description
Updated iOS and Android dependencies to version `4.1.0-beta1` of the ForgeRock Authenticator SDK.