### PR TITLE
SDKS-2569 Give an option to update an existing Account while scanning a QRCode

### DIFF
--- a/forgerock-authenticator/CHANGELOG.md
+++ b/forgerock-authenticator/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Updated
 
-- Android and iOS `forgerock-authenticator` dependency to the 4.1.0-beta1 release
+- Android and iOS `forgerock-authenticator` dependency to the 4.1.0 release
 - Sample app updated to use the new Authenticator policies feature
 
 ## [1.1.2]

--- a/forgerock-authenticator/android/build.gradle
+++ b/forgerock-authenticator/android/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-messaging:23.1.2'
     implementation 'com.google.android.gms:play-services-location:21.0.1'
 
-    implementation 'org.forgerock:forgerock-authenticator:4.1.0-beta1'
-    implementation 'org.forgerock:forgerock-core:4.1.0-beta1'
+    implementation 'org.forgerock:forgerock-authenticator:4.1.0'
+    implementation 'org.forgerock:forgerock-core:4.1.0'
 
     //add lib via aar-depency
 //    implementation(name: 'forgerock-authenticator-debug', ext: 'aar')

--- a/forgerock-authenticator/android/src/main/java/org/forgerock/android/auth/FRAClientWrapper.java
+++ b/forgerock-authenticator/android/src/main/java/org/forgerock/android/auth/FRAClientWrapper.java
@@ -179,7 +179,7 @@ public class FRAClientWrapper {
                     public void run() {
                         if (e instanceof DuplicateMechanismException)  {
                             flutterResult.error("DUPLICATE_MECHANISM_EXCEPTION", e.getLocalizedMessage(),
-                                    ((DuplicateMechanismException) e).getCausingMechanism().toJson());
+                                    ((DuplicateMechanismException) e).getCausingMechanism().getId());
                         } else if (e instanceof MechanismPolicyViolationException) {
                             flutterResult.error("POLICY_VIOLATION_EXCEPTION", e.getLocalizedMessage(),
                                     ((MechanismPolicyViolationException) e).getCausingPolicy().getName());

--- a/forgerock-authenticator/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/forgerock-authenticator/example/ios/Runner.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -348,6 +349,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/forgerock-authenticator/example/lib/providers/authenticator_provider.dart
+++ b/forgerock-authenticator/example/lib/providers/authenticator_provider.dart
@@ -61,7 +61,7 @@ class AuthenticatorProvider with ChangeNotifier {
       return mechanism;
     } on PlatformException catch (e) {
       if (e.code == ForgerockAuthenticator.DuplicateMechanismException) {
-        return Future<Mechanism>.error(DuplicateMechanismException());
+        return Future<Mechanism>.error(DuplicateMechanismException(e.details, e.message));
       }
       if (e.code == ForgerockAuthenticator.CreateMechanismException) {
         return Future<Mechanism>.error(MechanismCreationException(e.message));

--- a/forgerock-authenticator/ios/Classes/FRAClientWrapper.swift
+++ b/forgerock-authenticator/ios/Classes/FRAClientWrapper.swift
@@ -45,8 +45,8 @@ open class FRAClientWrapper {
             result(MechanismConverter.toJson(mechanism: mechanism))
         }, onError: { (error) in
             switch error {
-            case MechanismError.alreadyExists(let message):
-                result(FlutterError(code: "DUPLICATE_MECHANISM_EXCEPTION", message: error.localizedDescription, details: message))
+            case MechanismError.alreadyExists(let mechanismId):
+                result(FlutterError(code: "DUPLICATE_MECHANISM_EXCEPTION", message: error.localizedDescription, details: mechanismId))
                 break
             case AccountError.failToRegisterPolicyViolation(let policy):
                 result(FlutterError(code: "POLICY_VIOLATION_EXCEPTION", message: error.localizedDescription, details: policy))

--- a/forgerock-authenticator/ios/forgerock_authenticator.podspec
+++ b/forgerock-authenticator/ios/forgerock_authenticator.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.platform = :ios, '12.0'
   s.dependency 'Flutter'
-  s.dependency 'FRAuthenticator', '4.1.0-beta1'
+  s.dependency 'FRAuthenticator', '4.1.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/forgerock-authenticator/lib/exception/exceptions.dart
+++ b/forgerock-authenticator/lib/exception/exceptions.dart
@@ -8,15 +8,22 @@
 /// Exception thrown when a Mechanism was already registered
 class DuplicateMechanismException implements Exception {
   late String _message;
+  late String _mechanismId;
 
-  DuplicateMechanismException(
+  DuplicateMechanismException(String mechanismId,
       [String message = 'This authentication method is already registered.']) {
     this._message = message;
+    this._mechanismId = mechanismId;
   }
 
   @override
   String toString() {
     return _message;
+  }
+
+  /// Return the Id of the mechanism which caused the exception
+  String? getMechanismId() {
+    return _mechanismId;
   }
 }
 

--- a/forgerock-authenticator/lib/forgerock_authenticator.dart
+++ b/forgerock-authenticator/lib/forgerock_authenticator.dart
@@ -38,6 +38,10 @@ class ForgerockAuthenticator {
   static const PushRegistrationException = 'PUSH_REGISTRATION_EXCEPTION';
   static const PolicyViolationException = 'POLICY_VIOLATION_EXCEPTION';
 
+  static const PUSH_URI = 'pushauth';
+  static const OATH_URI = 'otpauth';
+  static const MFAUTH_URI = 'mfauth';
+
   //
   // Authenticator SDK methods
   //


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2569](https://bugster.forgerock.org/jira/browse/SDKS-2569) Give an option to update an existing Account while scanning a QRCode

# Description

While trying to register an Account that already exist on the Authenticator app the user receives a message that the Account is duplicated. This change will provide an option to update the existing account.

# Definition of Done Checklist:

- [x] Acceptance criteria is met.
- [x] Change log updated.
- [x] Ensure backward compatibility.
- [x] Unit tests are written.
- [ ] Functional spec is written/updated.
- [ ] Added example code snippets.